### PR TITLE
Raise Ed25519::VerifyError if signature verification fails

### DIFF
--- a/lib/ed25519/signing_key.rb
+++ b/lib/ed25519/signing_key.rb
@@ -7,12 +7,16 @@ module Ed25519
   class SigningKey
     attr_reader :verify_key
 
+    # Generate a random Ed25519 signing key (i.e. private scalar)
     def self.generate
-      new SecureRandom.random_bytes(Ed25519::SECRET_KEY_BYTES)
+      new SecureRandom.random_bytes(Ed25519::KEY_SIZE)
     end
 
+    # Create a new Ed25519::SigningKey from the given seed value
+    #
+    # @param seed [String] 32-byte seed value from which the key should be derived
     def initialize(seed)
-      raise ArgumentError, "seed must be 32 bytes long" unless seed.length == SECRET_KEY_BYTES
+      raise ArgumentError, "seed must be #{KEY_SIZE}-bytes long" unless seed.length == KEY_SIZE
       @seed = seed
 
       verify_key, @signing_key = Ed25519::Engine.create_keypair(seed)

--- a/lib/ed25519/verify_key.rb
+++ b/lib/ed25519/verify_key.rb
@@ -3,26 +3,42 @@
 module Ed25519
   # Public key for verifying digital signatures
   class VerifyKey
+    # Create a Ed25519::VerifyKey from its serialized Twisted Edwards representation
+    #
+    # @param key [String] 32-byte string representing a serialized public key
     def initialize(key)
-      raise ArgumentError, "seed must be 32 bytes long" unless key.length == PUBLIC_KEY_BYTES
-      @key = key
+      raise ArgumentError, "seed must be 32 bytes long" unless key.length == KEY_SIZE
+      @key_bytes = key
     end
 
+    # Verify an Ed25519 signature against the message
+    #
+    # @param signature [String] 64-byte string containing an Ed25519 signature
+    # @param message [String] string containing message to be verified
+    #
+    # @raise Ed25519::VerifyError signature verification failed
+    #
+    # @return [true] message verified successfully
     def verify(signature, message)
-      if signature.length != SIGNATURE_BYTES
-        raise ArgumentError, "expected #{SIGNATURE_BYTES} byte signature, got #{signature.length}"
+      if signature.length != SIGNATURE_SIZE
+        raise ArgumentError, "expected #{SIGNATURE_SIZE} byte signature, got #{signature.length}"
       end
 
-      Ed25519::Engine.verify(@key, signature, message)
+      return true if Ed25519::Engine.verify(@key_bytes, signature, message)
+      raise VerifyError, "signature verification failed!"
     end
 
-    def inspect
-      to_s
-    end
-
+    # Return a compressed twisted Edwards coordinate representing the public key
+    #
+    # @return [String] bytestring serialization of this public key
     def to_bytes
-      @key
+      @key_bytes
     end
     alias to_str to_bytes
+
+    # Show hex representation of serialized coordinate in string inspection
+    def inspect
+      "#<#{self.class}:#{@key_bytes.unpack('H*').first}>"
+    end
   end
 end

--- a/spec/ed25519/engine_spec.rb
+++ b/spec/ed25519/engine_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 RSpec.describe Ed25519::Engine do
-  let(:seed_length) { Ed25519::SECRET_KEY_BYTES }
+  let(:seed_length) { Ed25519::KEY_SIZE }
   let(:message)     { "foobar" }
 
   it "generates keypairs" do
@@ -13,13 +13,13 @@ RSpec.describe Ed25519::Engine do
     pubkey, privkey = ary
 
     expect(pubkey).to be_a String
-    expect(pubkey.length).to eq Ed25519::PUBLIC_KEY_BYTES
+    expect(pubkey.length).to eq Ed25519::KEY_SIZE
 
     expect(privkey).to be_a String
-    expect(privkey.length).to eq Ed25519::SECRET_KEY_BYTES * 2
+    expect(privkey.length).to eq Ed25519::KEY_SIZE * 2
   end
 
-  it "raises ArgumentError if the seed is not #{Ed25519::SECRET_KEY_BYTES} bytes long" do
+  it "raises ArgumentError if the seed is not #{Ed25519::KEY_SIZE} bytes long" do
     expect { Ed25519::Engine.create_keypair("A" * (seed_length - 1)) }.to raise_exception ArgumentError
     expect { Ed25519::Engine.create_keypair("A" * (seed_length + 1)) }.to raise_exception ArgumentError
   end

--- a/spec/ed25519/signing_key_spec.rb
+++ b/spec/ed25519/signing_key_spec.rb
@@ -18,6 +18,6 @@ RSpec.describe Ed25519::SigningKey do
   it "serializes to bytes" do
     bytes = key.to_bytes
     expect(bytes).to be_a String
-    expect(bytes.length).to eq 32
+    expect(bytes.length).to eq Ed25519::KEY_SIZE
   end
 end

--- a/spec/ed25519/verify_key_spec.rb
+++ b/spec/ed25519/verify_key_spec.rb
@@ -6,18 +6,20 @@ RSpec.describe Ed25519::VerifyKey do
   let(:signing_key) { Ed25519::SigningKey.generate }
   let(:verify_key)  { signing_key.verify_key }
   let(:message)     { "example message" }
+  let(:signature)   { signing_key.sign(message) }
 
-  it "verifies messages" do
-    signature = signing_key.sign(message)
-    expect(verify_key.verify(signature, message)).to be_truthy
+  it "verifies messages with good signatures" do
+    expect(verify_key.verify(signature, message)).to eq true
+  end
 
+  it "raises Ed25519::VerifyError on bad signatures" do
     bad_signature = signature[0...63] + "X"
-    expect(verify_key.verify(bad_signature, message)).to be_falsey
+    expect { verify_key.verify(bad_signature, message) }.to raise_error(Ed25519::VerifyError)
   end
 
   it "serializes to bytes" do
     bytes = verify_key.to_bytes
     expect(bytes).to be_a String
-    expect(bytes.length).to eq 32
+    expect(bytes.length).to eq Ed25519::KEY_SIZE
   end
 end


### PR DESCRIPTION
This should make failed signature verifications harder to ignore accidentally.