### PR TITLE
Keypair refactor

### DIFF
--- a/ext/ed25519_ref10/ed25519_ref10.c
+++ b/ext/ed25519_ref10/ed25519_ref10.c
@@ -23,7 +23,7 @@ void Init_ed25519_ref10()
 static VALUE mEd25519_Provider_Ref10_create_keypair(VALUE self, VALUE seed)
 {
     uint8_t verify_key[PUBLICKEYBYTES];
-    uint8_t signing_key[SECRETKEYBYTES];
+    uint8_t keypair[SECRETKEYBYTES];
 
     StringValue(seed);
 
@@ -31,12 +31,9 @@ static VALUE mEd25519_Provider_Ref10_create_keypair(VALUE self, VALUE seed)
         rb_raise(rb_eArgError, "seed must be exactly %d bytes", SECRETKEYBYTES / 2);
     }
 
-    crypto_sign_ed25519_ref10_seed_keypair(verify_key, signing_key, (uint8_t *)RSTRING_PTR(seed));
+    crypto_sign_ed25519_ref10_seed_keypair(verify_key, keypair, (uint8_t *)RSTRING_PTR(seed));
 
-    return rb_ary_new3(2,
-        rb_str_new((const char *)verify_key, PUBLICKEYBYTES),
-        rb_str_new((const char *)signing_key, SECRETKEYBYTES)
-    );
+    return rb_str_new((const char *)keypair, SECRETKEYBYTES);
 }
 
 static VALUE mEd25519_Provider_Ref10_sign(VALUE self, VALUE signing_key, VALUE msg)

--- a/lib/ed25519/provider/jruby.rb
+++ b/lib/ed25519/provider/jruby.rb
@@ -16,12 +16,12 @@ module Ed25519
 
         verify_key = org.cryptosphere.ed25519.publickey(seed.to_java_bytes)
         verify_key = String.from_java_bytes(verify_key)
-        [verify_key, seed + verify_key]
+        seed + verify_key
       end
 
       def sign(signing_key, message)
-        verify_key  = signing_key[32...64].to_java_bytes
-        signing_key = signing_key[0...32].to_java_bytes
+        verify_key  = signing_key[32, 32].to_java_bytes
+        signing_key = signing_key[0, 32].to_java_bytes
 
         signature = org.cryptosphere.ed25519.signature(message.to_java_bytes, signing_key, verify_key)
         String.from_java_bytes(signature)

--- a/lib/ed25519/signing_key.rb
+++ b/lib/ed25519/signing_key.rb
@@ -5,7 +5,7 @@ require "securerandom"
 module Ed25519
   # Private key for producing digital signatures
   class SigningKey
-    attr_reader :verify_key
+    attr_reader :seed, :keypair, :verify_key
 
     # Generate a random Ed25519 signing key (i.e. private scalar)
     def self.generate
@@ -19,8 +19,8 @@ module Ed25519
       raise ArgumentError, "seed must be #{KEY_SIZE}-bytes long" unless seed.length == KEY_SIZE
       @seed = seed
 
-      verify_key, @keypair = Ed25519.provider.create_keypair(seed)
-      @verify_key = VerifyKey.new(verify_key)
+      @keypair = Ed25519.provider.create_keypair(seed)
+      @verify_key = VerifyKey.new(@keypair[32, 32])
     end
 
     def sign(message)
@@ -32,7 +32,7 @@ module Ed25519
     end
 
     def to_bytes
-      @seed
+      seed
     end
     alias to_str to_bytes
   end

--- a/spec/support/provider_examples.rb
+++ b/spec/support/provider_examples.rb
@@ -5,16 +5,9 @@ RSpec.shared_examples "Ed25519::Provider" do
   let(:message)     { "foobar" }
 
   it "generates keypairs" do
-    ary = described_class.create_keypair("A" * seed_length)
-
-    expect(ary.length).to eq 2
-    pubkey, privkey = ary
-
-    expect(pubkey).to be_a String
-    expect(pubkey.length).to eq Ed25519::KEY_SIZE
-
-    expect(privkey).to be_a String
-    expect(privkey.length).to eq Ed25519::KEY_SIZE * 2
+    keypair = described_class.create_keypair("A" * seed_length)
+    expect(keypair).to be_a String
+    expect(keypair.length).to eq Ed25519::KEY_SIZE * 2
   end
 
   it "raises ArgumentError if the seed is not #{Ed25519::KEY_SIZE} bytes long" do
@@ -23,11 +16,13 @@ RSpec.shared_examples "Ed25519::Provider" do
   end
 
   it "signs and verifies messages" do
-    verify_key, signing_key = described_class.create_keypair("A" * seed_length)
-    signature = described_class.sign(signing_key, message)
-    expect(described_class.verify(verify_key, signature, message)).to be_truthy
+    keypair = described_class.create_keypair("A" * seed_length)
+    signature = described_class.sign(keypair, message)
+    verify_key = keypair[32, 32]
+
+    expect(described_class.verify(verify_key, signature, message)).to eq true
 
     bad_signature = signature[0...63] + "X"
-    expect(described_class.verify(verify_key, bad_signature, message)).to be_falsey
+    expect(described_class.verify(verify_key, bad_signature, message)).to eq false
   end
 end


### PR DESCRIPTION
Only return the keypair from keypair-related APIs, taking the last 32-byte half of the keypair as the verify key.