### PR TITLE
Support MRI 2.0+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: ruby
 
 rvm:
   - jruby-9.1.15.0
-  - 2.2.8
-  - 2.3.5
-  - 2.4.2
+  - 2
+  - 2.1
+  - 2.2
+  - 2.3.6
+  - 2.4.3
 
 before_install: gem install bundler -v 1.16.0
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,5 +8,5 @@ group :development, :test do
   gem "rake", require: false
   gem "rake-compiler", "~> 1.0", require: false
   gem "rspec", "~> 3.7", require: false
-  gem "rubocop", "0.51.0", require: false
+  gem "rubocop", "0.50.0", require: false
 end

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ You can read more on [Dan Bernstein's Ed25519 site](http://ed25519.cr.yp.to/).
 
 [Schnorr signature]: https://en.wikipedia.org/wiki/Schnorr_signature
 
+## Requirements
+
+**ed25519.rb** is tested on and supported by the following platforms:
+
+* MRI 2.0+
+* JRuby 9000+
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/ed25519.gemspec
+++ b/ed25519.gemspec
@@ -27,6 +27,6 @@ Gem::Specification.new do |spec|
     spec.extensions = ["ext/ed25519_ref10/extconf.rb"]
   end
 
-  spec.required_ruby_version = ">= 2.2.2"
+  spec.required_ruby_version = ">= 2.0.0"
   spec.add_development_dependency "bundler", "~> 1.16"
 end


### PR DESCRIPTION
It's not terribly difficult and the `Net::SSH` project would benefit from it.

We can drop support later when they do.