### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-packaging
+
 AllCops:
   TargetRubyVersion: 2.4
   DisplayCopNames: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,15 +16,12 @@ Gemspec/DuplicatedAssignment:
 # Layout
 #
 
-Lauout/LineLength:
+Layout/LineLength:
   Max: 128
 
 #
 # Lint
 #
-
-Lint/HandleExceptions:
-  Enabled: false
 
 Lint/SuppressedException:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :development, :test do
   gem "rake", require: false
   gem "rake-compiler", "~> 1.0", require: false
   gem "rspec", "~> 3.7", require: false
-  gem "rubocop", "0.75.0", require: false
+  gem "rubocop", "~> 0.88", require: false
   gem "rubocop-packaging", "~> 0.1.1", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,5 @@ group :development, :test do
   gem "rake-compiler", "~> 1.0", require: false
   gem "rspec", "~> 3.7", require: false
   gem "rubocop", "0.75.0", require: false
+  gem "rubocop-packaging", "~> 0.1.1", require: false
 end

--- a/ed25519.gemspec
+++ b/ed25519.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |spec|
   DESCRIPTION
   spec.homepage      = "https://github.com/crypto-rb/ed25519"
   spec.license       = "MIT"
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = Dir["{ext,lib}/**/*", "CHANGES.md", "LICENSE"]
   spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+  spec.extra_rdoc_files = ["README.md", "ed25519.png"]
 
   if defined? JRUBY_VERSION
     spec.platform = "java"

--- a/lib/ed25519.rb
+++ b/lib/ed25519.rb
@@ -5,7 +5,7 @@ require "ed25519/signing_key"
 require "ed25519/verify_key"
 
 # The Ed25519 digital signatre algorithm
-# rubocop:disable Metrics/LineLength,Style/IfUnlessModifier
+# rubocop:disable Layout/LineLength
 module Ed25519
   module_function
 
@@ -65,7 +65,7 @@ module Ed25519
     raise SelfTestFailure, "failed to detect an invalid signature" unless ex.is_a?(Ed25519::VerifyError)
   end
 end
-# rubocop:enable Metrics/LineLength,Style/IfUnlessModifier
+# rubocop:enable Layout/LineLength
 
 # Automatically run self-test when library loads
 Ed25519.self_test


### PR DESCRIPTION
Hi @tarcieri,

Thanks for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end-users and not other things which are not needed by them! :rocket: 

Also, added `rubocop-packaging` as a `development_dependency` which will ensure the best practices.
Here's what it shows:

```
➜  ed25519:(master) rubocop --only Packaging

Inspecting 14 files
..C..........

Offenses:

ed25519.gemspec:17:24: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
                       ^^^^^^^^^^^^^^^^^

14 files inspected, 1 offense detected
```

And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>