### PR TITLE
Bump rubocop dependencies.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - "**"
 
   pull_request:
     branches: [ master ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-    - "**"
+    branches: [ master ]
 
   pull_request:
     branches: [ master ]

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 AllCops:
   TargetRubyVersion: 2.4
   DisplayCopNames: true
+  NewCops: enable
 
 #
 # Gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -10,5 +10,5 @@ group :development, :test do
   gem "rake-compiler", "~> 1.0", require: false
   gem "rspec", "~> 3.7", require: false
   gem "rubocop", "~> 1.12.1", require: false
-  gem "rubocop-packaging", "~> 0.1.1", require: false
+  gem "rubocop-packaging", "~> 0.5.1", require: false
 end

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,6 @@ group :development, :test do
   gem "rake", require: false
   gem "rake-compiler", "~> 1.0", require: false
   gem "rspec", "~> 3.7", require: false
-  gem "rubocop", "~> 0.88", require: false
+  gem "rubocop", "~> 1.12.1", require: false
   gem "rubocop-packaging", "~> 0.1.1", require: false
 end

--- a/lib/ed25519.rb
+++ b/lib/ed25519.rb
@@ -55,7 +55,7 @@ module Ed25519
     verify_key = signature_key.verify_key
     raise SelfTestFailure, "failed to verify a valid signature" unless verify_key.verify(signature, message)
 
-    bad_signature = signature[0...63] + "X"
+    bad_signature = "#{signature[0...63]}X"
     ex = nil
     begin
       verify_key.verify(bad_signature, message)

--- a/spec/ed25519/verify_key_spec.rb
+++ b/spec/ed25519/verify_key_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Ed25519::VerifyKey do
   end
 
   it "raises Ed25519::VerifyError on bad signatures" do
-    bad_signature = signature[0...63] + "X"
+    bad_signature = "#{signature[0...63]}X"
     expect { verify_key.verify(bad_signature, message) }.to raise_error(Ed25519::VerifyError)
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "bundler/setup"
 require "ed25519"
 require "support/provider_examples"
 require "coveralls"

--- a/spec/support/provider_examples.rb
+++ b/spec/support/provider_examples.rb
@@ -22,7 +22,7 @@ RSpec.shared_examples "Ed25519::Provider" do
 
     expect(described_class.verify(verify_key, signature, message)).to eq true
 
-    bad_signature = signature[0...63] + "X"
+    bad_signature = "#{signature[0...63]}X"
     expect(described_class.verify(verify_key, bad_signature, message)).to eq false
   end
 end


### PR DESCRIPTION
## Changes in this PR

- Bump `rubocop` gem from 0.88 to 1.12.1.
  - 1.12.1 is last `rubocop` version to support Ruby 2.4.
- Bump `rubocop-packaging` gem from 0.1.1 to 0.5.1.
- Enable new cops in `.rubocop.yml`.
- Fix linting issue related to gems upgrade.

### Small Request for Hacktoberfest 2021

This code repo is currently not participating in Hacktoberfest with the `Hacktoberfest` topic.

If this PR is a candidate for merge, I will be really thankful if the `hacktoberfest-accepted` label could be added to this PR.

All this is optional of course.