### PR TITLE
Add support for Ruby 3 & JRuby 9.3.0.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,7 @@ name: CI
 
 on:
   push:
-    branches:
-    - "**"
+    branches: [ master ]
 
   pull_request:
     branches: [ master ]
@@ -12,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, jruby-9.2.19, truffleruby ]
+        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, jruby-9.2.19, jruby-9.3.0, truffleruby ]
         os: [ ubuntu-latest, windows-latest ]
         exclude:
           - { ruby: truffleruby, os: windows-latest }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,8 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches:
+    - "**"
 
   pull_request:
     branches: [ master ]
@@ -11,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, jruby-9.2.10, jruby-9.2.11, truffleruby ]
+        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, jruby-9.2.10, jruby-9.2.11, truffleruby ]
         os: [ ubuntu-latest, windows-latest ]
         exclude:
           - { ruby: truffleruby, os: windows-latest }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, jruby-9.2.10, jruby-9.2.11, truffleruby ]
+        ruby: [ ruby-2.4, ruby-2.5, ruby-2.6, ruby-2.7, ruby-3.0, jruby-9.2.19, truffleruby ]
         os: [ ubuntu-latest, windows-latest ]
         exclude:
           - { ruby: truffleruby, os: windows-latest }

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2017 Tony Arcieri
+Copyright (c) 2012-2021 Tony Arcieri
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Have questions? Want to suggest a feature or change? Join a discussion group:
 **ed25519.rb** is supported on and tested against the following platforms:
 
 * MRI 2.4, 2.5, 2.6, 2.7, 3.0
-* JRuby 9.2.10, 9.2.11
+* JRuby 9.2.19
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Have questions? Want to suggest a feature or change? Join a discussion group:
 **ed25519.rb** is supported on and tested against the following platforms:
 
 * MRI 2.4, 2.5, 2.6, 2.7, 3.0
-* JRuby 9.2.19
+* JRuby 9.2.19, 9.3.0
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Have questions? Want to suggest a feature or change? Join a discussion group:
 
 **ed25519.rb** is supported on and tested against the following platforms:
 
-* MRI 2.4, 2.5, 2.6, 2.7
+* MRI 2.4, 2.5, 2.6, 2.7, 3.0
 * JRuby 9.2.10, 9.2.11
 
 ## Installation
@@ -170,7 +170,7 @@ code of conduct.
 
 ## License
 
-Copyright (c) 2012-2020 Tony Arcieri. Distributed under the MIT License. See
+Copyright (c) 2012-2021 Tony Arcieri. Distributed under the MIT License. See
 [LICENSE] for further details.
 
 [LICENSE]: https://github.com/RubyCrypto/ed25519/blob/master/LICENSE

--- a/ed25519.gemspec
+++ b/ed25519.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
     A Ruby binding to the Ed25519 elliptic curve public-key signature system
     described in RFC 8032.
   DESCRIPTION
-  spec.homepage      = "https://github.com/crypto-rb/ed25519"
+  spec.homepage      = "https://github.com/RubyCrypto/ed25519"
   spec.license       = "MIT"
   spec.files         = Dir["{ext,lib}/**/*", "CHANGES.md", "LICENSE"]
   spec.bindir        = "exe"

--- a/lib/ed25519.rb
+++ b/lib/ed25519.rb
@@ -28,6 +28,7 @@ module Ed25519
 
   # Select the Ed25519::Provider to use based on the current environment
   if defined? JRUBY_VERSION
+    require "jruby"
     require "ed25519_jruby"
     self.provider = org.cryptorb.Ed25519Provider.createEd25519Module(JRuby.runtime)
   else


### PR DESCRIPTION
## Changes in this PR

- Add `ruby-3.0` to GitHub Actions & README.
- Add `jruby-9.3.0` to GitHub Actions & README.
  - Add changes to supoprt JRuby 9.3.0.
- Remove `jruby-9.2.10` from GitHub Actions & README.
- Bump from `jruby-9.2.11` from `jruby-9.2.19` in GitHub Actions & README.
- Update the year in README.
- Update home page URL in gemspec.

### Small Request for Hacktoberfest 2021

This code repo is currently not participating in Hacktoberfest with the `Hacktoberfest` topic.

If this PR is a candidate for merge, I will be really thankful if the `hacktoberfest-accepted` label could be added to this PR.

All this is optional of course.