### PR TITLE
v1.3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,13 @@
+## [1.3.0] (2022-01-16)
+
+[1.3.0]: https://github.com/crypto-rb/ed25519/compare/v1.2.4...v1.3.0
+
+- Bump rubocop dependencies. ([#30])
+- Add support for Ruby 3 & JRuby 9.3.0. ([#31])
+
+[#30]: https://github.com/crypto-rb/ed25519/pull/30
+[#31]: https://github.com/crypto-rb/ed25519/pull/31
+
 ## [1.2.4] (2018-01-04)
 
 [1.2.4]: https://github.com/crypto-rb/ed25519/compare/v1.2.3...v1.2.4

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [ci-image]: https://github.com/RubyCrypto/ed25519/workflows/CI/badge.svg
 [ci-link]: https://github.com/RubyCrypto/ed25519/actions?query=workflow%3ACI+branch%3Amaster
 [docs-image]: https://img.shields.io/badge/yard-docs-blue.svg
-[docs-link]: http://www.rubydoc.info/gems/ed25519/1.2.4
+[docs-link]: http://www.rubydoc.info/gems/ed25519/1.3.0
 [license-image]: https://img.shields.io/badge/license-MIT-blue.svg
 [license-link]: https://github.com/RubyCrypto/ed25519/blob/master/LICENSE
 

--- a/lib/ed25519/version.rb
+++ b/lib/ed25519/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ed25519
-  VERSION = "1.2.4"
+  VERSION = "1.3.0"
 end


### PR DESCRIPTION
- Bump rubocop dependencies. ([#30])
- Add support for Ruby 3 & JRuby 9.3.0. ([#31])

[#30]: https://github.com/crypto-rb/ed25519/pull/30
[#31]: https://github.com/crypto-rb/ed25519/pull/31