### PR TITLE
Now that Ruby 3.2 is available on Windows, re-enable it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
         os: [ ubuntu-latest, windows-latest ]
         exclude:
           - { ruby: truffleruby, os: windows-latest }
-          - { ruby: ruby-3.2, os: windows-latest }
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
@tarcieri There's now an image available, so this runs green.