### PR TITLE
Export to pem

### DIFF
--- a/lib/ed25519/verify_key.rb
+++ b/lib/ed25519/verify_key.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require "base64"
+require "openssl"
+
 module Ed25519
   # Public key for verifying digital signatures
   class VerifyKey
@@ -36,6 +39,28 @@ module Ed25519
       @key_bytes
     end
     alias to_str to_bytes
+
+    # Return a .pem representation of this public key
+    #
+    # @return [String] verify key converted to a pem string
+    def to_pem
+      # Create a subjectPublicKeyInfo object as defined in RFC8410
+      subject_public_key_info = OpenSSL::ASN1.Sequence(
+        [
+          OpenSSL::ASN1.Sequence(
+            [
+              OpenSSL::ASN1.ObjectId("ED25519")
+            ]
+          ),
+          OpenSSL::ASN1.BitString(to_bytes)
+        ]
+      )
+      <<~PEM
+        -----BEGIN PUBLIC KEY-----
+        #{Base64.strict_encode64(subject_public_key_info.to_der)}
+        -----END PUBLIC KEY-----
+      PEM
+    end
 
     # Show hex representation of serialized coordinate in string inspection
     def inspect

--- a/spec/ed25519/signing_key_spec.rb
+++ b/spec/ed25519/signing_key_spec.rb
@@ -36,4 +36,18 @@ RSpec.describe Ed25519::SigningKey do
       expect(bytes.length).to eq Ed25519::KEY_SIZE
     end
   end
+
+  describe "#to_pem" do
+    it "serializes to a private key format that can be used by OpenSSL" do
+      pem_formatted_key = key.to_pem
+      expect(pem_formatted_key).to be_a String
+      openssl_pkey = OpenSSL::PKey.read pem_formatted_key
+      expect(openssl_pkey).to be_a OpenSSL::PKey::PKey
+      expect(openssl_pkey.public_to_pem).to eq key.verify_key.to_pem
+      expect(openssl_pkey.private_to_pem).to eq pem_formatted_key
+      openssl_signature = openssl_pkey.sign(nil, message)
+      expect(key.verify_key.verify(openssl_signature, message)).to be true
+      expect { key.verify_key.verify(openssl_signature, "#{message}X") }.to raise_error(Ed25519::VerifyError)
+    end
+  end
 end

--- a/spec/ed25519/verify_key_spec.rb
+++ b/spec/ed25519/verify_key_spec.rb
@@ -22,4 +22,15 @@ RSpec.describe Ed25519::VerifyKey do
     expect(bytes).to be_a String
     expect(bytes.length).to eq Ed25519::KEY_SIZE
   end
+
+  it "serializes to a PEM public key format that can be used by OpenSSL" do
+    pem_formatted_key = verify_key.to_pem
+    expect(pem_formatted_key).to be_a String
+    openssl_pkey = OpenSSL::PKey.read pem_formatted_key
+    expect(openssl_pkey).to be_a OpenSSL::PKey::PKey
+    expect { openssl_pkey.private_to_pem }.to raise_error(OpenSSL::PKey::PKeyError)
+    expect(openssl_pkey.public_to_pem).to eq pem_formatted_key
+    expect(openssl_pkey.verify(nil, signature, message)).to be true
+    expect(openssl_pkey.verify(nil, signature, "#{message}X")).to be false
+  end
 end


### PR DESCRIPTION
This adds the ability to export signing keys and verifying keys as PEM formatted private and public keys. These exported PEM keys are compatible with OpenSSL. This enables easier interoperability with OpenSSL. For example one can sign a document using this library, and verify the signature using OpenSSL and the exported PEM key.

See [related support issue](https://github.com/RubyCrypto/ed25519/issues/42)